### PR TITLE
Adds integration with Inventory Profiles Next.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ dependencies {
 
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    modCompileOnly("org.anti-ad.mc:inventory-profiles-next:fabric-1.16.5-${project.IPN_version}") {
+        exclude group: "com.terraformersmc"
+        exclude module: "modmenu"
+    }
     compileOnly "com.google.code.findbugs:jsr305:+"
 
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,4 @@ archives_base_name=dankstorage
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 fabric_version=0.20.1+build.401-1.16
+IPN_version=1.1.0

--- a/src/main/java/tfar/dankstorage/client/screens/AbstractDankStorageScreen.java
+++ b/src/main/java/tfar/dankstorage/client/screens/AbstractDankStorageScreen.java
@@ -11,6 +11,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import org.anti_ad.mc.ipn.api.IPNIgnore;
 import tfar.dankstorage.client.button.SmallButton;
 import tfar.dankstorage.container.AbstractDankMenu;
 import tfar.dankstorage.inventory.DankSlot;
@@ -20,6 +21,7 @@ import tfar.dankstorage.utils.Utils;
 
 import java.util.List;
 
+@IPNIgnore
 public abstract class AbstractDankStorageScreen<T extends AbstractDankMenu> extends AbstractContainerScreen<T> {
 
     protected final boolean is7;


### PR DESCRIPTION
Adds integration with this mod https://www.curseforge.com/minecraft/mc-mods/inventory-profiles-next

In essence Inventory Profiles Next and Dank Storage are incompatible. 
IPN relies that all storage containers will handle clicks as in vanilla and will obey the stack limits. Since the core functionality of Dank Storage is to change the above it's not really possible to work towards compatibility,

The change adds annotation to AbstractDankStorageScreen that tells IPN to ignore all screens that inherit from AbstractDankStorageScreen.