### PR TITLE
Allow taking single stacks using Shift+Right click

### DIFF
--- a/src/main/java/tfar/dankstorage/container/AbstractDankMenu.java
+++ b/src/main/java/tfar/dankstorage/container/AbstractDankMenu.java
@@ -184,9 +184,24 @@ public abstract class AbstractDankMenu extends AbstractContainerMenu {
                     return;
                 }
 
-                for (ItemStack itemstack7 = this.quickMoveStack(player, slotId); !itemstack7.isEmpty() && ItemStack.isSame(slot5.getItem(), itemstack7); itemstack7 = this.quickMoveStack(player, slotId)) {
-                    itemstack = itemstack7.copy();
+                switch (dragType) {
+                    case 0: {
+                        // Left Click, move as much as possible
+
+                        for (ItemStack itemstack7 = this.quickMoveStack(player, slotId); !itemstack7.isEmpty() && ItemStack.isSame(slot5.getItem(), itemstack7); itemstack7 = this.quickMoveStack(player, slotId)) {
+                            itemstack = itemstack7.copy();
+                        }
+                        break;
+                    }
+                    case 1: {
+                        // Right Click, move single stack
+
+                        itemstack = this.quickMoveStack(player, slotId).copy();
+                        break;
+                    }
                 }
+
+
             } else {
                 if (slotId < 0) {
                     return;


### PR DESCRIPTION
Sometimes I want to quickly take a single or a few stacks from a dank container but not fill my entire inventory with cobblestone. This PR adds the functionality to quickly move one stack (64 for most items, 16 for enderpearls etc...) from the dank inventory to the player inventory by right clicking while holding shift.