### PR TITLE
Fix canceling upgrade & broken upgrading on 3rd party crafting tables

### DIFF
--- a/src/main/java/tfar/dankstorage/DankStorage.java
+++ b/src/main/java/tfar/dankstorage/DankStorage.java
@@ -23,6 +23,8 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.Material;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tfar.dankstorage.block.DankDispenserBehavior;
 import tfar.dankstorage.block.DockBlock;
 import tfar.dankstorage.client.Client;
@@ -45,6 +47,7 @@ public class DankStorage implements ModInitializer, ClientModInitializer,
         ServerLifecycleEvents.ServerStarted, ServerLifecycleEvents.ServerStopped, CommandRegistrationCallback {
 
     public static final String MODID = "dankstorage";
+    public static final Logger LOGGER = LogManager.getLogger(MODID);
 
     public static Block dock;
     public static MenuType<DockMenu> dank_1_container;

--- a/src/main/java/tfar/dankstorage/blockentity/DockBlockEntity.java
+++ b/src/main/java/tfar/dankstorage/blockentity/DockBlockEntity.java
@@ -144,9 +144,13 @@ public class DockBlockEntity extends BlockEntity implements Nameable, MenuProvid
 
         DankInventory dankInventory = getInventory();
 
-        if (dankInventory.dankStats != DankStats.values()[tier]) {
-            Utils.warn(player, DankStats.values()[tier], dankInventory.dankStats);
-            return null;
+        DankStats type = DankStats.values()[tier];
+        if (type != dankInventory.dankStats) {
+            if (type.ordinal() < dankInventory.dankStats.ordinal()) {
+                Utils.warn(player, type, dankInventory.dankStats);
+                return null;
+            }
+            dankInventory.upgradeTo(type);
         }
 
         return switch (getBlockState().getValue(DockBlock.TIER)) {
@@ -213,14 +217,20 @@ public class DockBlockEntity extends BlockEntity implements Nameable, MenuProvid
             CompoundTag iSettings = Utils.getSettings(tank);
             tank.shrink(1);
 
+            DankInventory dankInventory;
             if (iSettings != null && iSettings.contains(Utils.ID)) {
                 this.settings = iSettings;
+                dankInventory = DankStorage.instance.data.getInventory(iSettings.getInt(Utils.ID));
             } else {
                 this.settings = new CompoundTag();
                 int newId = DankStorage.instance.data.getNextID();
-                DankStorage.instance.data.getOrCreateInventory(newId, stats);
+                dankInventory = DankStorage.instance.data.getOrCreateInventory(newId, stats);
                 settings.putInt(Utils.ID, newId);
             }
+            if (stats != dankInventory.dankStats) {
+                dankInventory.upgradeTo(stats);
+            }
+
             setChanged();
         }
     }

--- a/src/main/java/tfar/dankstorage/container/PortableDankProvider.java
+++ b/src/main/java/tfar/dankstorage/container/PortableDankProvider.java
@@ -46,9 +46,12 @@ public class PortableDankProvider implements MenuProvider {
                 dankInventory = DankStorage.instance.data
                         .getOrCreateInventory(next,type);
                 Utils.getSettings(bag).putInt(Utils.ID,next);
-        } else if (dankInventory.dankStats != type) {
-            Utils.warn(player,type,dankInventory.dankStats);
-            return null;
+        } else if (type != dankInventory.dankStats) {
+            if (type.ordinal() < dankInventory.dankStats.ordinal()) {
+                Utils.warn(player, type, dankInventory.dankStats);
+                return null;
+            }
+            dankInventory.upgradeTo(type);
         }
 
         return switch (type) {

--- a/src/main/java/tfar/dankstorage/event/MixinHooks.java
+++ b/src/main/java/tfar/dankstorage/event/MixinHooks.java
@@ -5,6 +5,7 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import tfar.dankstorage.DankStorage;
 import tfar.dankstorage.container.DankMenu;
 import tfar.dankstorage.item.DankItem;
 import tfar.dankstorage.utils.ItemHandlerHelper;
@@ -43,7 +44,7 @@ public class MixinHooks {
         DankInventory inv = Utils.getInventory(dank,player.level);
 
         if (inv == null) {
-            System.out.println("That's odd, the player somehow got an unassigned dank to change pickup mode");
+            DankStorage.LOGGER.warn("That's odd, the player somehow got an unassigned dank to change pickup mode");
             return false;
         }
 

--- a/src/main/java/tfar/dankstorage/network/server/C2SMessageTogglePickup.java
+++ b/src/main/java/tfar/dankstorage/network/server/C2SMessageTogglePickup.java
@@ -22,7 +22,6 @@ public class C2SMessageTogglePickup implements ServerPlayNetworking.PlayChannelH
 
     public void handle(ServerPlayer player) {
         ItemStack bag = player.getMainHandItem();
-        System.out.println(bag);
         if (!(bag.getItem() instanceof DankItem)) {
             bag = player.getOffhandItem();
             if (!(bag.getItem() instanceof DankItem)) return;

--- a/src/main/java/tfar/dankstorage/recipe/UpgradeRecipe.java
+++ b/src/main/java/tfar/dankstorage/recipe/UpgradeRecipe.java
@@ -27,19 +27,6 @@ public class UpgradeRecipe extends ShapedRecipe {
         ItemStack oldBag = inv.getItem(4);
         //can't upgrade the backing inventory because there isn't one yet
         if (!oldBag.hasTag()) return newBag;
-
-        AbstractContainerMenu menu = ((CraftingContainerAccess)inv).getMenu();
-
-        int id = Utils.getFrequency(oldBag);
-        if (menu instanceof CraftingMenu && id > -1) {
-            if (!((CraftingMenuAccess) menu).getPlayer().level.isClientSide) {
-                DankInventory inventory = DankStorage.instance.data.getInventory(id);
-                inventory.upgradeTo(Utils.getStats(newBag));
-            } else {
-                System.out.println("Why is someone trying to craft items clientside, now they won't have the correct data.");
-                new RuntimeException().printStackTrace();
-            }
-        }
         newBag.setTag(oldBag.getTag());
         return newBag;
     }

--- a/src/main/java/tfar/dankstorage/world/DankInventory.java
+++ b/src/main/java/tfar/dankstorage/world/DankInventory.java
@@ -38,6 +38,9 @@ public class DankInventory extends SimpleContainer implements ContainerData {
         if (stats.ordinal() <= dankStats.ordinal()) {
             return;
         }
+        if (stats != dankStats) {
+            DankStorage.LOGGER.debug("Upgrading dank #{} from tier {} to {}", id, dankStats.name(), stats.name());
+        }
         setTo(stats);
     }
 

--- a/src/main/java/tfar/dankstorage/world/DankSavedData.java
+++ b/src/main/java/tfar/dankstorage/world/DankSavedData.java
@@ -6,6 +6,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.saveddata.SavedData;
+import tfar.dankstorage.DankStorage;
 import tfar.dankstorage.utils.DankStats;
 import tfar.dankstorage.utils.Utils;
 
@@ -85,7 +86,7 @@ public class DankSavedData extends SavedData {
     @Override
     public void save(File file) {
         super.save(file);
-        System.out.println("Saving Dank Contents");
+        DankStorage.LOGGER.info("Saving Dank Contents");
     }
 
     public void clearAll() {


### PR DESCRIPTION
The current solution of checking for dank tiers is completely broken, as
it relies on `ShapedRecipe::assemble()`, which is called *even if the item
doesn't get crafted* in many circumstances, including vanilla and even
more so on 3rd-party crafting stations such as Improved Stations.

This changes the mod to do inventory upgrades passively; namely when the
player open a Dank, puts one in a Dock, or opens a docked Dank (not
necessary; for good measure), which cover all the ways an inventory can
get accessed (by player or otherwise) after a crafted upgrade.
The upgrade item scenario is already covered by current code.

Also introduces the use of loggers instead of `System.out`.